### PR TITLE
Voters titles changed to Voters from preliminary lists

### DIFF
--- a/src/components/components/bulgaria_map/BulgariaMap.js
+++ b/src/components/components/bulgaria_map/BulgariaMap.js
@@ -89,20 +89,20 @@ const MapControlsSingleParty = styled.div`
 import regionPaths from './regionPaths';
 
 import {
-    generateTooltipDominant, 
-    generateTooltipSingleParty, 
-    generateTooltipTurnout, 
-    generateTooltipVoters, 
+    generateTooltipDominant,
+    generateTooltipSingleParty,
+    generateTooltipTurnout,
+    generateTooltipVoters,
     generateNullTooltip,
     generateTooltipCoverage,
     generateTooltipProcessed
 } from './generateTooltipContent';
 
-import { 
-    generateDisplayParties, 
-    generateRegionDataDominant, 
-    generateRegionDataSingleParty, 
-    generateRegionDataTurnout, 
+import {
+    generateDisplayParties,
+    generateRegionDataDominant,
+    generateRegionDataSingleParty,
+    generateRegionDataTurnout,
     generateRegionDataVoters,
     generateRegionDataCoverage,
     generateRegionDataProcessed
@@ -156,7 +156,7 @@ export default handleViewport(props => {
             <button className={mode === 'dominant'? 'selected' : ''} onClick={()=>setMode('dominant')}>Водеща партия</button>
             <button className={mode === 'single-party'? 'selected' : ''} onClick={()=>setMode('single-party')}>Отделна партия</button>
             {/*<button className={mode === 'turnout'? 'selected' : ''} onClick={()=>setMode('turnout')}>Активност</button>*/}
-            <button className={mode === 'voters'? 'selected' : ''} onClick={()=>setMode('voters')}>Избиратели</button>
+            <button className={mode === 'voters'? 'selected' : ''} onClick={()=>setMode('voters')}>Избиратели в предварителните списъци</button>
             {/*<button className={mode === 'coverage'? 'selected' : ''} onClick={()=>setMode('coverage')}>Покритие</button>*/}
             <button className={mode === 'sectionsWithResults'? 'selected' : ''} onClick={()=>setMode('sectionsWithResults')}>%Обработени</button>
         </MapControls>,
@@ -170,14 +170,14 @@ export default handleViewport(props => {
                 </button>
             )
         }
-            <div style={{width: '100%'}}>    
+            <div style={{width: '100%'}}>
                 <button className={singlePartyMode === 'percentage'? 'selected' : ''} onClick={()=>setSinglePartyMode('percentage')}>Процент</button>
                 <button className={singlePartyMode === 'votes'? 'selected' : ''} onClick={()=>setSinglePartyMode('votes')}>Гласове</button>
             </div>
         </MapControlsSingleParty> : null,
         <BulgariaMapStyle>
-        <StyledTooltip 
-            multiline={true} 
+        <StyledTooltip
+            multiline={true}
             html={true}
             border={true}
             borderColor={'#aaa'}

--- a/src/components/components/bulgaria_map/generateTooltipContent.js
+++ b/src/components/components/bulgaria_map/generateTooltipContent.js
@@ -132,7 +132,7 @@ export const generateTooltipVoters = (region, tooltipData) => {
             <table style="width: 100%;">
             <tbody>
                 <tr>
-                    <td style="padding-right: 20px;">Избиратели</td>
+                    <td style="padding-right: 20px;">Избиратели в предварителните списъци</td>
                     <td style="text-align: right;">${formatCount(tooltipData.voters)}</td>
                 </tr>
                 <tr>

--- a/src/components/components/subdivision_table/sortSubdivisionTable.js
+++ b/src/components/components/subdivision_table/sortSubdivisionTable.js
@@ -45,7 +45,7 @@ export const sortTableDistribution = (subdivisions, singleParty) => {
     }
 
     return sortSignals(subdivisions);
-};  
+};
 
 export const sortTableVoters = (subdivisions) => {
     let highestCount = 0;
@@ -59,7 +59,7 @@ export const sortTableVoters = (subdivisions) => {
     for(const subdivision of subdivisions) {
         const currentCount = subdivision.stats.voters;
         subdivision.percentage = currentCount / highestCount;
-        subdivision.tooltipField = 'Избиратели';
+        subdivision.tooltipField = 'Избиратели в предварителните списъци';
         subdivision.tooltipValue = formatCount(subdivision.stats.voters);
     }
 

--- a/src/components/units/Section.js
+++ b/src/components/units/Section.js
@@ -8,7 +8,7 @@ import LoadingScreen from '../layout/LoadingScreen';
 
 import ResultsTable from '../components/results_table/ResultsTable';
 
-import { ElectionContext } from '../Election'; 
+import { ElectionContext } from '../Election';
 import Crumbs from '../components/Crumbs';
 
 import styled from 'styled-components';
@@ -63,9 +63,9 @@ export default props => {
                 <Crumbs data={data} embed={props.embed}/>
                 <h1 style={props.embed? {fontSize: '15px'} : {}}>Секция {data.segment}</h1>
                 <ResultsTable
-                    results={data.results} 
-                    parties={parties} 
-                    totalValid={data.stats.validVotes} 
+                    results={data.results}
+                    parties={parties}
+                    totalValid={data.stats.validVotes}
                     totalInvalid={data.stats.invalidVotes}
                     embed={props.embed}
                 />
@@ -77,7 +77,7 @@ export default props => {
                             <td>{data.segment}</td>
                         </tr>
                         {
-                            data.crumbs.map((crumb, i) => i === 0? null : 
+                            data.crumbs.map((crumb, i) => i === 0? null :
                                 <tr>
                                     <td>{mapNodeType(crumb.type)}</td>
                                     <td>{crumb.name}</td>
@@ -98,7 +98,7 @@ export default props => {
                 <SectionDetailsTable>
                     <tbody>
                         <tr>
-                            <td>Избиратели</td>
+                            <td>Избиратели в предварителните списъци</td>
                             <td>{data.stats.voters}</td>
                         </tr>
                         <tr>


### PR DESCRIPTION
Провокиран от следната дискусия ви изпращам един малък PR.
https://m.facebook.com/groups/1007765125974606/permalink/3905150042902752/

Навсякъде Избиратели са всъщност предварително записаните в избирателните списъци граждани, и някои от организаторите в чужбина намират тази разлика за смущаваща. 
Другия подход би бил, да се смени в API, да подава сумирания брой гласували избирали от предварителните списъци и с декларация 22.

Другите промени са от автоматичните ми настройки на PHPstorm-a.