### PR TITLE
Draft: feat: Add variable length lines for risk displays

### DIFF
--- a/src/components/components/PercentageLine.js
+++ b/src/components/components/PercentageLine.js
@@ -1,0 +1,143 @@
+import React, { useRef } from 'react'
+import handleViewport from 'react-in-viewport'
+import styled from 'styled-components'
+import { formatCount, formatPercentage } from '../Util'
+
+// ----------------------------------------------------------------------------
+// Utils
+// ----------------------------------------------------------------------------
+
+const RISKS = [
+  {
+    displayName: `Висок риск`,
+    name: `High`,
+    color: `#9C1414`,
+  },
+  {
+    displayName: `Среден риск`,
+    name: `Medium`,
+    color: `#F7B00D`,
+  },
+  {
+    displayName: `Нисък риск`,
+    name: `Low`,
+    color: `#0a7399`,
+  },
+]
+
+// ----------------------------------------------------------------------------
+// Utils
+// ----------------------------------------------------------------------------
+
+const generateTooltip = (color, riskName, percentage, count) => {
+  return `
+      <div>
+        <h2 style="margin: 5px; color: #${color}">
+          ${riskName} 
+          ${
+            percentage
+              ? `<span style="float: right; margin-left: 20px;">${formatPercentage(
+                  percentage
+                )}%</span>`
+              : ``
+          }
+            
+        </h2>
+        <hr style="border-color: #aaa; border-top: none;"/>
+        <table style="width: 100%;">
+        <tbody>
+          <tr>
+            <td style="padding-right: 20px;">Брой секции</td>
+            <td style="text-align: right;">
+              ${formatCount(count)}
+            </td> 
+          </tr>
+        </tbody>
+        </table>
+      </div>
+    `
+}
+
+// ----------------------------------------------------------------------------
+// Sub-components
+// ----------------------------------------------------------------------------
+
+const ResultLineSegment = styled.div`
+  display: inline-block;
+  background-color: #777;
+  height: 50px;
+  transition: width 1s ease;
+  width: 0;
+
+  text-align: center;
+  color: white;
+  ${(props) => (props.embed ? `font-size: 11px;` : 'font-size: 16px;')}
+  font-weight: bold;
+
+  &.thin {
+    height: 20px;
+  }
+  &.ultra-thin {
+    height: 15px;
+  }
+  &:hover {
+    box-shadow: 0px 0px 3px #000;
+  }
+`
+
+// ----------------------------------------------------------------------------
+// Component
+// ----------------------------------------------------------------------------
+
+export default handleViewport((props) => {
+  const { inViewport, forwardedRef } = props
+  const alreadyLoaded = useRef(false)
+  if (inViewport) alreadyLoaded.current = true
+
+  const riskWithPercentages = ({ highRisk, midRisk, sectionsCount }) => {
+    const percentage = {
+      High: highRisk / sectionsCount,
+      Medium: midRisk / sectionsCount,
+      Low: (sectionsCount - (highRisk + midRisk)) / sectionsCount,
+    }
+
+    const count = {
+      High: highRisk,
+      Medium: midRisk,
+      Low: sectionsCount - (highRisk + midRisk),
+    }
+
+    return RISKS.map((risk) => {
+      risk.percentage = percentage[risk.name]
+      risk.count = count[risk.name]
+
+      return risk
+    })
+  }
+
+  return (
+    <div className="results-line" ref={forwardedRef}>
+      {[
+        riskWithPercentages(props).map((risk, i) => {
+          return (
+            <ResultLineSegment
+              key={i}
+              className={props.embed ? 'ultra-thin' : props.thin ? 'thin' : ''}
+              style={{
+                backgroundColor: `${risk.color}`,
+                width: `${risk.percentage * 100}%`,
+              }}
+              data-tip={generateTooltip(
+                risk.color,
+                risk.displayName,
+                risk.percentage,
+                risk.count
+              )}
+              data-for={`subdivisionTableTooltip`}
+            />
+          )
+        }),
+      ]}
+    </div>
+  )
+})

--- a/src/components/components/PercentageLine.js
+++ b/src/components/components/PercentageLine.js
@@ -4,7 +4,7 @@ import styled from 'styled-components'
 import { formatCount, formatPercentage } from '../Util'
 
 // ----------------------------------------------------------------------------
-// Utils
+// Const
 // ----------------------------------------------------------------------------
 
 const RISKS = [
@@ -58,6 +58,27 @@ const generateTooltip = (color, riskName, percentage, count) => {
     `
 }
 
+const riskWithPercentages = ({ highRisk, midRisk, sectionsCount }) => {
+  const percentage = {
+    High: highRisk / sectionsCount,
+    Medium: midRisk / sectionsCount,
+    Low: (sectionsCount - (highRisk + midRisk)) / sectionsCount,
+  }
+
+  const count = {
+    High: highRisk,
+    Medium: midRisk,
+    Low: sectionsCount - (highRisk + midRisk),
+  }
+
+  return RISKS.map((risk) => {
+    risk.percentage = percentage[risk.name]
+    risk.count = count[risk.name]
+
+    return risk
+  })
+}
+
 // ----------------------------------------------------------------------------
 // Sub-components
 // ----------------------------------------------------------------------------
@@ -93,27 +114,6 @@ export default handleViewport((props) => {
   const { inViewport, forwardedRef } = props
   const alreadyLoaded = useRef(false)
   if (inViewport) alreadyLoaded.current = true
-
-  const riskWithPercentages = ({ highRisk, midRisk, sectionsCount }) => {
-    const percentage = {
-      High: highRisk / sectionsCount,
-      Medium: midRisk / sectionsCount,
-      Low: (sectionsCount - (highRisk + midRisk)) / sectionsCount,
-    }
-
-    const count = {
-      High: highRisk,
-      Medium: midRisk,
-      Low: sectionsCount - (highRisk + midRisk),
-    }
-
-    return RISKS.map((risk) => {
-      risk.percentage = percentage[risk.name]
-      risk.count = count[risk.name]
-
-      return risk
-    })
-  }
 
   return (
     <div className="results-line" ref={forwardedRef}>

--- a/src/components/components/subdivision_table/SubdivisionTableRow.js
+++ b/src/components/components/subdivision_table/SubdivisionTableRow.js
@@ -1,18 +1,18 @@
 import React, { useRef } from 'react'
 
-import { Link } from 'react-router-dom'
 import handleViewport from 'react-in-viewport'
+import { Link } from 'react-router-dom'
 
+import PercentageLine from '../PercentageLine.js'
 import ResultsLine from '../ResultsLine.js'
 import SimpleLine from '../SimpleLine'
 
-import styled from 'styled-components'
-import { mapNodesType } from '../../ResultUnit.js'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import {
-  faExclamationTriangle,
   faExclamationCircle,
+  faExclamationTriangle,
 } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import styled from 'styled-components'
 
 import { formatCount } from '../../Util'
 import { rgbGradient } from '../bulgaria_map/generateRegionData.js'
@@ -52,44 +52,19 @@ export default handleViewport((props) => {
   if (inViewport) alreadyLoaded.current = true
   const shouldLoad = inViewport || alreadyLoaded.current
 
-  const renderSimpleLine = () => {
-    let percentage
-    let tooltipField
-    let tooltipValue
-
-    if (props.mode === 'turnout') {
-      let stats = props.subdivision.stats
-      percentage = (stats.validVotes + stats.invalidVotes) / stats.voters
-      tooltipField = 'Активност'
-    } else if (props.mode === 'voters') {
-      p
-    }
-
-    return (
-      <SimpleLine
-        percentage={percentage}
-        tooltipTitle={props.subdivision.name}
-        tooltipField={tooltipField}
-        tooltipValue={tooltipValue}
-        embed={props.embed}
-        thin
-      />
-    )
-  }
-
   const generateTooltip = (text, count) => {
     return `
             <div>
-                <table style="width: 100%;">
-                <tbody>
-                    <tr>
-                        <td>${text}</td>
-                        <td style="text-align: right; padding-left: 20px;">${formatCount(
-                          count
-                        )}</td> 
-                    </tr>
-                </tbody>
-                </table>
+              <table style="width: 100%;">
+              <tbody>
+                <tr>
+                  <td>${text}</td>
+                  <td style="text-align: right; padding-left: 20px;">
+                    ${formatCount(count)}
+                  </td> 
+                </tr>
+              </tbody>
+              </table>
             </div>
         `
   }
@@ -116,37 +91,6 @@ export default handleViewport((props) => {
           )}
         </td>
       </SubdivisionTableRowStyle>
-      {/*,
-            props.subdivision.nodes.length <= 1? null :
-            <SubdivisionTableRowStyle ref={forwardedRef} style={{opacity: shouldLoad? 1 : 0, transition: 'opacity 1s ease'}} 
-                type={props.type === 'top' ? 'middle' : 'bottom'}
-            >
-                <td style={props.type === 'top'? {fontSize: '28px'} : {}}>
-                    <b>Общо ({props.subdivision.nodes.length} {mapNodesType(props.subdivision.nodesType)})</b>
-                </td>
-                <td style={{borderBottom: '1px solid #ccc', paddingBottom: '10px'}}>
-                {
-                    props.mode === 'distribution'?
-                        <ResultsLine
-                            results={props.subdivision.results} 
-                            parties={props.parties}
-                            totalValid={props.subdivision.totalValid} 
-                            totalInvalid={props.subdivision.totalInvalid}
-                            firstParty={props.singleParty === ''? null : props.singleParty}
-                            embed={props.embed}
-                            thin
-                        /> :
-                        <SimpleLine
-                            percentage={props.subdivision.percentage}
-                            tooltipTitle={props.subdivision.name}
-                            tooltipField={props.subdivision.tooltipField}
-                            tooltipValue={props.subdivision.tooltipValue}
-                            embed={props.embed}
-                            thin
-                        />
-                }
-                </td>
-            </SubdivisionTableRowStyle>,*/}
     </>
   ) : (
     <>
@@ -190,7 +134,7 @@ export default handleViewport((props) => {
                 </span>
               )}
 
-              {props.subdivision.stats.violationsCount < 1 ? null : (
+              {props.subdivision.stats.violationsCount > 0 && (
                 <span
                   style={{
                     color: rgbGradient(
@@ -227,7 +171,7 @@ export default handleViewport((props) => {
           )}
         </td>
         <td>
-          {props.mode === 'distribution' ? (
+          {props.mode === 'distribution' && (
             <ResultsLine
               name={props.subdivision.name}
               results={props.subdivision.results}
@@ -238,16 +182,27 @@ export default handleViewport((props) => {
               embed={props.embed}
               thin
             />
-          ) : (
-            <SimpleLine
-              percentage={props.subdivision.percentage}
-              tooltipTitle={props.subdivision.name}
-              tooltipField={props.subdivision.tooltipField}
-              tooltipValue={props.subdivision.tooltipValue}
+          )}
+          {props.mode === 'sectionsWithResults' && (
+            <PercentageLine
               embed={props.embed}
+              highRisk={props.subdivision.stats.highRisk}
+              midRisk={props.subdivision.stats.midRisk}
+              sectionsCount={props.subdivision.stats.sectionsCount}
               thin
             />
           )}
+          {props.mode !== 'distribution' &&
+            props.mode !== 'sectionsWithResults' && (
+              <SimpleLine
+                percentage={props.subdivision.percentage}
+                tooltipTitle={props.subdivision.name}
+                tooltipField={props.subdivision.tooltipField}
+                tooltipValue={props.subdivision.tooltipValue}
+                embed={props.embed}
+                thin
+              />
+            )}
         </td>
       </SubdivisionTableRowStyle>
     </>


### PR DESCRIPTION
Added variable length lines for all risk displays:
1. Added a new `PercentageLine` component
2. Display that component in all subdivision displays, when `mode` is `sectionsWithResults`