### PR TITLE
feat: Show correct sectionMode everywhere

### DIFF
--- a/src/components/components/bulgaria_map/BulgariaMap.js
+++ b/src/components/components/bulgaria_map/BulgariaMap.js
@@ -222,6 +222,8 @@ export default handleViewport(
     linkToMainSite,
     loadViolationsForRegion,
     filters,
+    sectionsMode,
+    setSectionsMode,
   }) => {
     const alreadyLoaded = useRef(false)
     if (inViewport) alreadyLoaded.current = true
@@ -230,7 +232,7 @@ export default handleViewport(
     const history = useHistory()
     const [singleParty, setSingleParty] = useState('')
     const [singlePartyMode, setSinglePartyMode] = useState('percentage')
-    const [sectionsMode, setSectionsMode] = useState('risk')
+    // const [sectionsMode, setSectionsMode] = useState('risk')
 
     const regionData = generateRegionData(
       regions,

--- a/src/components/components/bulgaria_map/BulgariaMap.js
+++ b/src/components/components/bulgaria_map/BulgariaMap.js
@@ -232,7 +232,6 @@ export default handleViewport(
     const history = useHistory()
     const [singleParty, setSingleParty] = useState('')
     const [singlePartyMode, setSinglePartyMode] = useState('percentage')
-    // const [sectionsMode, setSectionsMode] = useState('risk')
 
     const regionData = generateRegionData(
       regions,

--- a/src/components/components/subdivision_table/SubdivisionTable.js
+++ b/src/components/components/subdivision_table/SubdivisionTable.js
@@ -138,22 +138,11 @@ export default (props) => {
 
   useEffect(() => {
     ReactTooltip.rebuild()
-  }, [mode])
-  useEffect(() => {
-    ReactTooltip.rebuild()
-  }, [singleParty])
-
-  useEffect(() => {
-    ReactTooltip.rebuild()
-  }, [depthMode])
+  }, [mode, singleParty, depthMode, sectionsMode])
   useEffect(() => {
     ReactTooltip.rebuild()
     setMode(getSelectedMode())
   }, [props?.selectedMode])
-  useEffect(() => {
-    ReactTooltip.rebuild()
-  }, [sectionsMode])
-
   const getSelectedMode = () => {
     const mode = props?.selectedMode
     switch (mode) {

--- a/src/components/components/subdivision_table/SubdivisionTable.js
+++ b/src/components/components/subdivision_table/SubdivisionTable.js
@@ -1,8 +1,8 @@
-import React, { useState, useEffect } from 'react'
+import React, { useEffect, useState } from 'react'
 
 import ReactTooltip from 'react-tooltip'
-import SubdivisionTableRow from './SubdivisionTableRow'
 import { mapNodeType } from '../../ResultUnit'
+import SubdivisionTableRow from './SubdivisionTableRow'
 
 import { useParams } from 'react-router-dom'
 
@@ -10,10 +10,11 @@ import styled from 'styled-components'
 import { generateDisplayParties } from '../bulgaria_map/generateRegionData'
 import {
   sortTableDistribution,
-  sortTableVoters,
+  sortTablePopulated,
+  sortTableSections,
   sortTableTurnout,
   sortTableViolations,
-  sortTableSections,
+  sortTableVoters,
 } from './sortSubdivisionTable'
 
 const StyledTooltip = styled(ReactTooltip)`
@@ -133,6 +134,7 @@ export default (props) => {
     props.resultsAvailable ? 'distribution' : 'violations'
   )
   const [singleParty, setSingleParty] = useState('')
+  const { sectionsMode } = props
 
   useEffect(() => {
     ReactTooltip.rebuild()
@@ -140,6 +142,7 @@ export default (props) => {
   useEffect(() => {
     ReactTooltip.rebuild()
   }, [singleParty])
+
   useEffect(() => {
     ReactTooltip.rebuild()
   }, [depthMode])
@@ -147,6 +150,9 @@ export default (props) => {
     ReactTooltip.rebuild()
     setMode(getSelectedMode())
   }, [props?.selectedMode])
+  useEffect(() => {
+    ReactTooltip.rebuild()
+  }, [sectionsMode])
 
   const getSelectedMode = () => {
     const mode = props?.selectedMode
@@ -200,7 +206,12 @@ export default (props) => {
       case 'turnout':
         return sortTableTurnout(subdivisions)
       case 'sectionsWithResults':
-        return sortTableSections(subdivisions)
+        if (sectionsMode === 'risk') {
+          return sortTableSections(subdivisions)
+        }
+        if (sectionsMode === 'populated') {
+          return sortTablePopulated(subdivisions)
+        }
       case 'violations':
         return sortTableViolations(subdivisions)
     }
@@ -247,6 +258,7 @@ export default (props) => {
         unit={unit}
         parties={props.parties}
         mode={mode}
+        sectionsMode={sectionsMode}
         embed={props.embed}
         type={type}
       />

--- a/src/components/components/subdivision_table/SubdivisionTableRow.js
+++ b/src/components/components/subdivision_table/SubdivisionTableRow.js
@@ -183,15 +183,27 @@ export default handleViewport((props) => {
               thin
             />
           )}
-          {props.mode === 'sectionsWithResults' && (
-            <PercentageLine
-              embed={props.embed}
-              highRisk={props.subdivision.stats.highRisk}
-              midRisk={props.subdivision.stats.midRisk}
-              sectionsCount={props.subdivision.stats.sectionsCount}
-              thin
-            />
-          )}
+          {props.mode === 'sectionsWithResults' &&
+            props.sectionsMode === 'risk' && (
+              <PercentageLine
+                embed={props.embed}
+                highRisk={props.subdivision.stats.highRisk}
+                midRisk={props.subdivision.stats.midRisk}
+                sectionsCount={props.subdivision.stats.sectionsCount}
+                thin
+              />
+            )}
+          {props.mode === 'sectionsWithResults' &&
+            props.sectionsMode === 'populated' && (
+              <SimpleLine
+                percentage={props.subdivision.percentage}
+                tooltipTitle={props.subdivision.name}
+                tooltipField={props.subdivision.tooltipField}
+                tooltipValue={props.subdivision.tooltipValue}
+                embed={props.embed}
+                thin
+              />
+            )}
           {props.mode !== 'distribution' &&
             props.mode !== 'sectionsWithResults' && (
               <SimpleLine

--- a/src/components/components/subdivision_table/sortSubdivisionTable.js
+++ b/src/components/components/subdivision_table/sortSubdivisionTable.js
@@ -68,6 +68,26 @@ export const sortTableSections = (subdivisions) => {
   return sortSignals(subdivisions)
 }
 
+export const sortTablePopulated = (subdivisions) => {
+  let highestCount = 0
+  for (const subdivision of subdivisions) {
+    const currentCount = subdivision.stats.populated
+
+    if (currentCount > highestCount) highestCount = currentCount
+  }
+
+  for (const subdivision of subdivisions) {
+    const currentCount = subdivision.stats.populated
+    subdivision.percentage = currentCount / highestCount
+    subdivision.tooltipField = 'Запълнени секции'
+    subdivision.tooltipValue = formatCount(subdivision.stats.populated)
+  }
+
+  subdivisions.sort((s1, s2) => s2.percentage - s1.percentage)
+
+  return sortSignals(subdivisions)
+}
+
 export const sortTableVoters = (subdivisions) => {
   let highestCount = 0
   for (const subdivision of subdivisions) {

--- a/src/components/units/Aggregation.js
+++ b/src/components/units/Aggregation.js
@@ -88,6 +88,7 @@ export default (props) => {
   const [streamsAvailable, setStreamsAvailable] = useState(false)
   const [sectionsWithResults, setSectionsWithResults] = useState(false)
   const [populatedSections, setPopulatedSections] = useState(false)
+  const [sectionsMode, setSectionsMode] = useState('risk')
   const { unit } = useParams()
   const history = useHistory()
 
@@ -159,6 +160,8 @@ export default (props) => {
           }}
           mode={selectedMode}
           setMode={(mode) => setSelectedMode(mode)}
+          sectionsMode={sectionsMode}
+          setSectionsMode={(sectionsMode) => setSectionsMode(sectionsMode)}
         />
       )}
 
@@ -188,6 +191,7 @@ export default (props) => {
             subdivisions={data.nodes.map(aggregateData)}
             embed={props.embed}
             selectedMode={selectedMode}
+            sectionsMode={sectionsMode}
           />
 
           {selectedMode == 'violations' && (


### PR DESCRIPTION
A fix to show the correct sectionMode (when on the `sectionsWithResults` mode) including:
1. Lifting `sectionMode` one component higher, so it can be passed down to Subdivisions
2. Adding tooltips and lines for populated sections
3. Moved all conditions for the useEffect refresh of the tooltips to the same array

TODO: Need to refactor how `SubdivisionTableRow` decides on which Line to show, as too conditional currently (and repetitive).
TODO: Need to refactor the logic on how all the subdivision data is added, as it is too repetitive.