### PR TITLE
Добавяне на recaptcha при изпращане на сигнал/протокол

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,4 @@
 NODE_ENV=development
 PUBLIC_URL=/
 DATA_URL=https://d1tapi.dabulgaria.bg
+GOOGLE_RECAPTCHA_KEY=6LfqhYUkAAAAAAp-KRpwLPTROD1jrAQlQQV_L8R8

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,7 @@ jobs:
         env:
           DATA_URL: ${{ secrets.STAGING_DATA_URL }}
           PUBLIC_URL: ${{ secrets.STAGING_PUBLIC_URL }}
+          GOOGLE_RECAPTCHA_KEY: ${{ secrets.GOOGLE_RECAPTCHA_KEY }}
           NODE_ENV: production
 
       - name: Minio Deploy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ jobs:
         env:
           DATA_URL: ${{ secrets.PRODUCTION_DATA_URL }}
           PUBLIC_URL: ${{ secrets.PRODUCTION_PUBLIC_URL }}
+          GOOGLE_RECAPTCHA_KEY: ${{ secrets.GOOGLE_RECAPTCHA_KEY }}
           NODE_ENV: production
 
       - name: Minio Deploy

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "react-burger-menu": "^3.0.6",
         "react-dom": "^17.0.1",
         "react-filepond": "^7.1.2",
+        "react-google-recaptcha-v3": "^1.10.1",
         "react-helmet": "^6.1.0",
         "react-hook-form": "^7.43.1",
         "react-image-gallery": "^1.2.7",
@@ -5903,6 +5904,18 @@
         "filepond": ">=3.7.x < 5.x",
         "react": "16 - 18",
         "react-dom": "16 - 18"
+      }
+    },
+    "node_modules/react-google-recaptcha-v3": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/react-google-recaptcha-v3/-/react-google-recaptcha-v3-1.10.1.tgz",
+      "integrity": "sha512-K3AYzSE0SasTn+XvV2tq+6YaxM+zQypk9rbCgG4OVUt7Rh4ze9basIKefoBz9sC0CNslJj9N1uwTTgRMJQbQJQ==",
+      "dependencies": {
+        "hoist-non-react-statics": "^3.3.2"
+      },
+      "peerDependencies": {
+        "react": "^16.3 || ^17.0 || ^18.0",
+        "react-dom": "^17.0 || ^18.0"
       }
     },
     "node_modules/react-helmet": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "react-burger-menu": "^3.0.6",
     "react-dom": "^17.0.1",
     "react-filepond": "^7.1.2",
+    "react-google-recaptcha-v3": "^1.10.1",
     "react-helmet": "^6.1.0",
     "react-hook-form": "^7.43.1",
     "react-image-gallery": "^1.2.7",

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -6,6 +6,7 @@ import Election from './Election'
 
 import styled from 'styled-components'
 import Embed from './Embed'
+import { GoogleReCaptchaProvider } from 'react-google-recaptcha-v3'
 
 export const Wrapper = styled.div`
   max-width: 900px;
@@ -34,14 +35,19 @@ export default (props) => {
   const publicURL = process.env.PUBLIC_URL ? process.env.PUBLIC_URL : '/'
 
   return (
-    <GlobalCSS>
-      <BrowserRouter basename={publicURL}>
-        <Switch>
-          <Route path="/embed" component={Embed} />
-          <Route path="/" component={Election} />
-          <Redirect to="/" />
-        </Switch>
-      </BrowserRouter>
-    </GlobalCSS>
+    <GoogleReCaptchaProvider
+      reCaptchaKey="6LfqhYUkAAAAAAp-KRpwLPTROD1jrAQlQQV_L8R8"
+      language="bg"
+    >
+      <GlobalCSS>
+        <BrowserRouter basename={publicURL}>
+          <Switch>
+            <Route path="/embed" component={Embed} />
+            <Route path="/" component={Election} />
+            <Redirect to="/" />
+          </Switch>
+        </BrowserRouter>
+      </GlobalCSS>
+    </GoogleReCaptchaProvider>
   )
 }

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -33,12 +33,10 @@ const GlobalCSS = styled.div`
 
 export default (props) => {
   const publicURL = process.env.PUBLIC_URL ? process.env.PUBLIC_URL : '/'
+  const reCaptchaKey = process.env.GOOGLE_RECAPTCHA_KEY
 
   return (
-    <GoogleReCaptchaProvider
-      reCaptchaKey="6LfqhYUkAAAAAAp-KRpwLPTROD1jrAQlQQV_L8R8"
-      language="bg"
-    >
+    <GoogleReCaptchaProvider reCaptchaKey={reCaptchaKey} language="bg">
       <GlobalCSS>
         <BrowserRouter basename={publicURL}>
           <Switch>

--- a/src/components/ProtocolForm.js
+++ b/src/components/ProtocolForm.js
@@ -4,7 +4,7 @@ import api from '../utils/api'
 import UploadPhotos from './UploadPhotos'
 import { saveImages } from '../utils/uploadPhotosHelper'
 import { ValidationError } from '../utils/ValidationError'
-import { GoogleReCaptcha } from 'react-google-recaptcha-v3'
+import { useGoogleReCaptcha } from 'react-google-recaptcha-v3'
 
 const ProtocolFormStyle = styled.form`
   .errorMsg {
@@ -51,13 +51,12 @@ const ProtocolFormStyle = styled.form`
 export const ProtocolForm = () => {
   const [files, setFiles] = useState([])
   const [error, setError] = useState(null)
-  const [recaptchaToken, setRecaptchaToken] = useState(null)
+  const { executeRecaptcha } = useGoogleReCaptcha()
   const [isSubmitted, setIsSubmitted] = useState(false)
 
   const handlePhotoUpload = (files) => {
     setFiles(files)
   }
-  const handleVerify = (token) => setRecaptchaToken(token)
   const handleSubmit = async (event) => {
     event.preventDefault()
     try {
@@ -68,6 +67,7 @@ export const ProtocolForm = () => {
       const body = {
         pictures: savedImageIds,
       }
+      const recaptchaToken = await executeRecaptcha('sendProtocol')
       void (await api.post('protocols', body, {
         headers: { 'x-recaptcha-token': recaptchaToken },
       }))
@@ -102,7 +102,6 @@ export const ProtocolForm = () => {
           callback={handlePhotoUpload}
           isRequired={true}
         ></UploadPhotos>
-        <GoogleReCaptcha onVerify={handleVerify} />
         <div className="form-control">
           <label></label>
           <button type="submit">Изпрати протокол</button>

--- a/src/components/ProtocolForm.js
+++ b/src/components/ProtocolForm.js
@@ -4,6 +4,7 @@ import api from '../utils/api'
 import UploadPhotos from './UploadPhotos'
 import { saveImages } from '../utils/uploadPhotosHelper'
 import { ValidationError } from '../utils/ValidationError'
+import { GoogleReCaptcha } from 'react-google-recaptcha-v3'
 
 const ProtocolFormStyle = styled.form`
   .errorMsg {
@@ -50,12 +51,13 @@ const ProtocolFormStyle = styled.form`
 export const ProtocolForm = () => {
   const [files, setFiles] = useState([])
   const [error, setError] = useState(null)
+  const [recaptchaToken, setRecaptchaToken] = useState(null)
   const [isSubmitted, setIsSubmitted] = useState(false)
 
   const handlePhotoUpload = (files) => {
     setFiles(files)
   }
-
+  const handleVerify = (token) => setRecaptchaToken(token)
   const handleSubmit = async (event) => {
     event.preventDefault()
     try {
@@ -66,7 +68,9 @@ export const ProtocolForm = () => {
       const body = {
         pictures: savedImageIds,
       }
-      void (await api.post('protocols', body))
+      void (await api.post('protocols', body, {
+        headers: { 'x-recaptcha-token': recaptchaToken },
+      }))
       setError(null)
       setFiles([])
     } catch (e) {
@@ -98,6 +102,7 @@ export const ProtocolForm = () => {
           callback={handlePhotoUpload}
           isRequired={true}
         ></UploadPhotos>
+        <GoogleReCaptcha onVerify={handleVerify} />
         <div className="form-control">
           <label></label>
           <button type="submit">Изпрати протокол</button>

--- a/src/components/ViolationForm.js
+++ b/src/components/ViolationForm.js
@@ -5,6 +5,7 @@ import api from '../utils/api'
 import { SectionSelector } from './sectionSelector/SectionSelector'
 import UploadPhotos from './UploadPhotos'
 import { saveImages, convertImagesToBase64 } from '../utils/uploadPhotosHelper'
+import { GoogleReCaptcha } from 'react-google-recaptcha-v3'
 
 const CommentFormStyle = styled.form`
   width: 100%;
@@ -65,11 +66,14 @@ export const ViolationForm = () => {
   } = methods
   const [message, setMessage] = useState('')
   const [key, setKey] = useState(0)
+  const [recaptchaToken, setRecaptchaToken] = useState(null)
   const [files, setFiles] = useState([])
 
   const handlePhotoUpload = (files) => {
     setFiles(files)
   }
+
+  const handleVerify = (token) => setRecaptchaToken(token)
 
   useEffect(() => {
     if (isSubmitSuccessful) {
@@ -87,7 +91,9 @@ export const ViolationForm = () => {
       }
       data.section ? (body['section'] = data.section) : body
       savedImageIds ? (body['pictures'] = savedImageIds) : body
-      void (await api.post('violations', body))
+      void (await api.post('violations', body, {
+        headers: { 'x-recaptcha-token': recaptchaToken },
+      }))
       setMessage('Сигналът Ви беше изпратен успешно!')
     } catch (error) {
       setMessage(`Сигналът Ви не беше изпратен!: ${error.message}`)
@@ -97,6 +103,7 @@ export const ViolationForm = () => {
   return (
     <FormProvider {...methods}>
       <CommentFormStyle onSubmit={handleSubmit(onSubmit)}>
+        <GoogleReCaptcha onVerify={handleVerify} />
         <SectionSelector
           key={key}
           errors={errors}

--- a/webpack/base.config.js
+++ b/webpack/base.config.js
@@ -49,7 +49,7 @@ module.exports = env => {
         plugins: [
             new CleanWebpackPlugin(),
             new LoadablePlugin(),
-            new CopyWebpackPlugin({ patterns: [ { from: './static/' } ]}),
+            new CopyWebpackPlugin({ patterns: [{ from: './static/' }] }),
             new HtmlWebpackPlugin({
                 title: 'Ти Броиш',
                 template: 'src/index.ejs',
@@ -60,6 +60,7 @@ module.exports = env => {
                     'NODE_ENV': JSON.stringify(process.env.NODE_ENV),
                     'PUBLIC_URL': JSON.stringify(process.env.PUBLIC_URL),
                     'DATA_URL': JSON.stringify(process.env.DATA_URL),
+                    'GOOGLE_RECAPTCHA_KEY': JSON.stringify(process.env.GOOGLE_RECAPTCHA_KEY),
                 },
             }),
         ],


### PR DESCRIPTION
Closes #47 
При верификация се добавя header x-recaptcha-token към `post` заявката.
Както при изпращане на сигнал така и на протокол.