### PR TITLE
Компресиране на изображения преди качване

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@videojs/plugin-concat": "^1.0.0",
         "axios": "^0.22.0",
         "babel-loader": "^8.2.2",
+        "browser-image-compression": "^2.0.2",
         "clean-webpack-plugin": "^3.0.0",
         "copy-webpack-plugin": "^8.0.0",
         "css-loader": "^5.1.2",
@@ -2528,6 +2529,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/browser-image-compression": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/browser-image-compression/-/browser-image-compression-2.0.2.tgz",
+      "integrity": "sha512-pBLlQyUf6yB8SmmngrcOw3EoS4RpQ1BcylI3T9Yqn7+4nrQTXJD4sJDe5ODnJdrvNMaio5OicFo75rDyJD2Ucw==",
+      "dependencies": {
+        "uzip": "0.20201231.0"
       }
     },
     "node_modules/browser-resolve": {
@@ -7035,6 +7044,11 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
+    },
+    "node_modules/uzip": {
+      "version": "0.20201231.0",
+      "resolved": "https://registry.npmjs.org/uzip/-/uzip-0.20201231.0.tgz",
+      "integrity": "sha512-OZeJfZP+R0z9D6TmBgLq2LHzSSptGMGDGigGiEe0pr8UBe/7fdflgHlHBNDASTXB5jnFuxHpNaJywSg8YFeGng=="
     },
     "node_modules/value-equal": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@videojs/plugin-concat": "^1.0.0",
     "axios": "^0.22.0",
     "babel-loader": "^8.2.2",
+    "browser-image-compression": "^2.0.2",
     "clean-webpack-plugin": "^3.0.0",
     "copy-webpack-plugin": "^8.0.0",
     "css-loader": "^5.1.2",

--- a/src/components/UploadPhotos.js
+++ b/src/components/UploadPhotos.js
@@ -9,7 +9,7 @@ import FilePondPluginFileValidateType from 'filepond-plugin-file-validate-type'
 import api from '../utils/api'
 import 'filepond-plugin-image-preview/dist/filepond-plugin-image-preview.css'
 import { useGoogleReCaptcha } from 'react-google-recaptcha-v3'
-
+import imageCompression from 'browser-image-compression'
 registerPlugin(
   FilePondPluginImageExifOrientation,
   FilePondPluginImagePreview,
@@ -72,19 +72,19 @@ const uploadImage =
     transfer,
     options
   ) => {
-    const reader = new FileReader()
     const abortController = new AbortController()
+    const compressionOptions = {
+      maxSizeMB: 50,
+      maxWidthOrHeight: 10000,
+      useWebWorker: true,
+    }
+    try {
+      const compressedFile = await imageCompression(file, compressionOptions)
+      const reader = new FileReader()
 
-    reader.readAsDataURL(file)
-    reader.onload = async () => {
-      const encodedDataURL = reader.result
-      const byteSize = (str) => new Blob([str]).size
-      const imageMB = byteSize(encodedDataURL) / Math.pow(1024, 2)
-      if (Math.round(imageMB) > 50) {
-        error(`Размерът на файла ${file.name}  е твърде голям`)
-        return
-      }
-      try {
+      reader.readAsDataURL(compressedFile)
+      reader.onload = async () => {
+        const encodedDataURL = reader.result
         const savedImage = await api.post(
           'pictures',
           {
@@ -98,19 +98,20 @@ const uploadImage =
           }
         )
         load(savedImage.id)
-      } catch (err) {
-        error('Възникна грешка при качването на снимките')
-      }
-    }
 
-    reader.onerror = () => {
+        reader.onerror = () => {
+          error('Възникна грешка при качването на снимките')
+        }
+        load(savedImage.id)
+      }
+    } catch (error) {
+      console.log(error)
       error('Възникна грешка при качването на снимките')
     }
 
     return {
       abort: () => {
         abortController.abort()
-        reader.abort()
         abort()
       },
     }

--- a/src/components/UploadPhotos.js
+++ b/src/components/UploadPhotos.js
@@ -74,7 +74,7 @@ const uploadImage =
   ) => {
     const abortController = new AbortController()
     const compressionOptions = {
-      maxSizeMB: 50,
+      maxSizeMB: 2,
       maxWidthOrHeight: 10000,
       useWebWorker: true,
     }

--- a/src/components/UploadPhotos.js
+++ b/src/components/UploadPhotos.js
@@ -75,7 +75,7 @@ const uploadImage =
     const abortController = new AbortController()
     const compressionOptions = {
       maxSizeMB: 2,
-      maxWidthOrHeight: 10000,
+      maxWidthOrHeight: 4000,
       useWebWorker: true,
     }
     try {


### PR DESCRIPTION
Closes #110 

Моля да се тества отново все пак. При мен сработи и резултатите са:
<img width="309" alt="Screenshot 2023-04-01 at 16 49 05" src="https://user-images.githubusercontent.com/1280694/229293218-2004dd75-4ad5-4a62-acbd-cab8611de97b.png">

За максималния размер не успях да тествам, така че ако имате под ръка подходящ файл ще е хубаво да се провери дали сработа от https://www.npmjs.com/package/browser-image-compression 