### PR TITLE
Build for 2026-04-19 parliamentary election

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "build": "NODE_OPTIONS=--openssl-legacy-provider node -r dotenv/config node_modules/.bin/webpack --config webpack/build.config.js",
-    "build:prod": "NODE_OPTIONS=--openssl-legacy-provider node -r dotenv/config node_modules/.bin/webpack --env DATA_URL=https://api.tibroish.bg --env PUBLIC_URL=/results/2026-04-19 --env NODE_ENV=production --config webpack/build.config.js",
+    "build:prod": "NODE_OPTIONS=--openssl-legacy-provider DATA_URL=https://api.tibroish.bg PUBLIC_URL=/results/parliament-2026-04-19 NODE_ENV=production node node_modules/.bin/webpack --config webpack/build.config.js",
     "serve": "NODE_OPTIONS=--openssl-legacy-provider node -r dotenv/config node_modules/.bin/webpack serve --env DATA_URL=https://d1tapi.tibroish.bg --config webpack/serve.config.js",
     "serve:prod": "NODE_OPTIONS=--openssl-legacy-provider node -r dotenv/config node_modules/.bin/webpack serve --env DATA_URL=https://api.tibroish.bg --config webpack/serve.config.js",
     "serve:local": "NODE_OPTIONS=--openssl-legacy-provider DATA_URL=http://localhost:4000 node -r dotenv/config node_modules/.bin/webpack serve --config webpack/serve.config.js",

--- a/src/components/Submit.js
+++ b/src/components/Submit.js
@@ -3,6 +3,7 @@ import styled from 'styled-components'
 import { LinkButton } from './components/Link'
 import { ROUTES } from './routes'
 import { ElectionContext } from './Election'
+import { shouldAllowSendingProtocols } from '../utils/visibility'
 
 const HorizontalLinks = styled.div`
   display: flex;
@@ -13,6 +14,8 @@ const HorizontalLinks = styled.div`
 export const Submit = () => {
   const [hasViolations, setHasViolations] = useState(false)
   const [hasProtcols, setHasProtocols] = useState(false)
+  const { meta } = useContext(ElectionContext)
+  const allowProtocols = shouldAllowSendingProtocols(meta)
 
   useEffect(() => {
     if (!localStorage) {
@@ -26,14 +29,16 @@ export const Submit = () => {
   }, [])
   return (
     <HorizontalLinks>
-      <LinkButton to={ROUTES.protocolForm}>Изпрати протокол</LinkButton>
+      {allowProtocols && (
+        <LinkButton to={ROUTES.protocolForm}>Изпрати протокол</LinkButton>
+      )}
       <LinkButton to={ROUTES.violationForm}>Подай сигнал</LinkButton>
       {hasViolations && (
         <>
           <LinkButton to={ROUTES.myViolations}>Моите сигнали</LinkButton>
         </>
       )}
-      {hasProtcols && (
+      {allowProtocols && hasProtcols && (
         <>
           <LinkButton to={ROUTES.myProtocols}>Моите протоколи</LinkButton>
         </>


### PR DESCRIPTION
## Summary

- \`build:prod\` uses shell env vars (\`DATA_URL\`, \`PUBLIC_URL\`, \`NODE_ENV\`) so they reach DefinePlugin. The prior \`--env FOO=BAR\` form populated webpack's config-function \`env\` param only, not \`process.env\`, so DefinePlugin saw \`undefined\`.
- \`PUBLIC_URL\` bumped to \`/results/parliament-2026-04-19\`.
- \`Submit.js\`: gate "Изпрати протокол" and "Моите протоколи" on \`shouldAllowSendingProtocols(meta)\` — hide protocol CTAs until the end of election day per \`meta.endOfElectionDayTimestamp\`.

## Test plan

- [ ] \`npm run build:prod\` produces a bundle with the correct \`DATA_URL\` and \`PUBLIC_URL\` baked in
- [ ] Deployed to minio at \`results/parliament-2026-04-19/\` and loaded at \`https://tibroish.bg/results/parliament-2026-04-19/\`
- [ ] Before \`endOfElectionDayTimestamp\`: protocol CTAs hidden on \`/submit\`; violation CTA still visible
- [ ] After \`endOfElectionDayTimestamp\`: protocol CTAs visible