### PR TITLE
Bump release/deploy workflows to Node 20

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '20'
           cache: npm
 
       - name: Clean install of dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '20'
           cache: npm
 
       - name: Clean install of dependencies


### PR DESCRIPTION
copy-webpack-plugin@14 requires Node 20+. Aligns release.yml and deploy.yml with .nvmrc/engines/ci.yml (already on Node 20).