### PR TITLE
Fix sections not filtering by city region

### DIFF
--- a/src/components/sectionSelector/SectionSelector.js
+++ b/src/components/sectionSelector/SectionSelector.js
@@ -127,7 +127,7 @@ export const SectionSelector = ({ register, errors, setValue }) => {
       cache,
       town && (!townHasCityRegions || cityRegion)
         ? `sections?town=${town}${
-            cityRegion ? `&cityRegion=${cityRegion}` : ''
+            cityRegion ? `&city_region=${cityRegion}` : ''
           }`
         : null,
       (list) => list.sort(abcSorter('code'))


### PR DESCRIPTION
## Summary
- The `cityRegion` query parameter sent to `GET /sections` used camelCase, but the API expects `city_region` (snake_case), so the filter was silently ignored
- For cities like Sofia that span multiple election regions (23, 24, 25), this caused all ~1,450 sections to appear instead of only those in the selected city region (~50-120)

## Test plan
- [ ] On /violations/new, select a Sofia district (e.g. "23 София 23 МИР"), pick a municipality and town (гр.София), then a city region (e.g. Красно Село) — verify only ~93 sections appear, not ~1,000+
- [ ] Verify the staging API: `GET /sections?town=68134&city_region=02` returns ~93 sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)