### PR TITLE
Inline video signal form on section page

### DIFF
--- a/src/components/ViolationFeeds.js
+++ b/src/components/ViolationFeeds.js
@@ -10,7 +10,7 @@ import { formatDateTime } from './Util'
 import styled from 'styled-components'
 
 import { Fade } from 'react-awesome-reveal'
-import { Link, LinkButton } from './components/Link'
+import { Link } from './components/Link'
 
 const ViolationFeed = styled.div`
   max-width: 600px;
@@ -198,9 +198,7 @@ export default (props) => {
         <LoadingScreen />
       ) : (
         <>
-          <LinkButton to={`/violation/new?unit=${unit}`}>
-            Подай сигнал
-          </LinkButton>
+          <Link to={`/violation/new?unit=${unit}`}>Подай сигнал &rarr;</Link>
           {violationData?.items.length > 0 ? (
             <ViolationFeed>
               {violationData.items.map(renderViolation)}

--- a/src/components/ViolationForm.js
+++ b/src/components/ViolationForm.js
@@ -54,15 +54,10 @@ const createSchema = (isVideo) =>
             : input
         )
         .required(requiredMessage),
-      description: isVideo
-        ? yup
-            .string()
-            .min(5, 'Моля въведете поне 5 символа')
-            .required(requiredMessage)
-        : yup
-            .string()
-            .min(20, 'Моля въведете поне 20 символа')
-            .required(requiredMessage),
+      description: yup
+        .string()
+        .min(20, 'Моля въведете поне 20 символа')
+        .required(requiredMessage),
       electionRegion: yup.string().when('isAbroad', {
         is: false,
         then: (x) => x.required(requiredMessage),
@@ -295,14 +290,10 @@ export const ViolationForm = () => {
           <Textarea
             name="description"
             required={true}
-            minLength={isVideo ? 5 : 20}
-            pattern={isVideo ? '.{5,}' : '.{20,}'}
+            minLength={20}
+            pattern=".{20,}"
             label="Описание на нарушението"
-            title={
-              isVideo
-                ? 'Моля въведете поне 5 символа за описание на нарушението'
-                : 'Моля въведете поне 20 символа за описание на нарушението'
-            }
+            title="Моля въведете поне 20 символа за описание на нарушението"
             register={register}
             errors={errors}
           />

--- a/src/components/ViolationForm.js
+++ b/src/components/ViolationForm.js
@@ -10,6 +10,7 @@ import { SectionSelector } from './sectionSelector/SectionSelector'
 import { ElectionContext } from './Election'
 import { shouldShowOfficialStreaming } from '../utils/visibility'
 import api from '../utils/api'
+import { getSavedContact } from '../utils/contact'
 import { ROUTES } from './routes'
 import { Link, LinkButton } from './components/Link'
 import { Button } from './components/Button'
@@ -76,14 +77,6 @@ const createSchema = (isVideo) =>
       }),
     })
     .required()
-
-const getSavedContact = () => {
-  try {
-    return JSON.parse(localStorage.getItem('violationContact')) || {}
-  } catch (e) {
-    return {}
-  }
-}
 
 export const ViolationForm = () => {
   const location = useLocation()

--- a/src/components/units/Section.js
+++ b/src/components/units/Section.js
@@ -1,8 +1,9 @@
-import React, { useContext, useEffect, useState, useRef } from 'react'
+import React, { useContext, useEffect, useState } from 'react'
 
 import axios from 'axios'
 import Helmet from 'react-helmet'
 import { useHistory, useParams } from 'react-router-dom'
+import { useGoogleReCaptcha } from 'react-google-recaptcha-v3'
 import { mapNodeType } from '../ResultUnit'
 import LoadingScreen from '../layout/LoadingScreen'
 
@@ -18,6 +19,13 @@ import styled from 'styled-components'
 import ViolationFeeds from '../ViolationFeeds'
 import Player from '../embeds/Player'
 import { shouldShowOfficialStreaming } from '../../utils/visibility'
+import {
+  getSavedContact,
+  saveContact,
+  formatPhone,
+  isValidPhone,
+  isValidEmail,
+} from '../../utils/contact'
 import { Button } from '../components/Button'
 import api from '../../utils/api'
 
@@ -109,9 +117,11 @@ const VideoPanel = styled.div`
       display: flex;
       gap: 8px;
       margin-top: 8px;
+      flex-wrap: wrap;
 
       input {
         flex: 1;
+        min-width: 150px;
         padding: 8px 10px;
         font-size: 14px;
         border: 1px solid #ccc;
@@ -142,14 +152,6 @@ const VideoPanel = styled.div`
   }
 `
 
-const getSavedContact = () => {
-  try {
-    return JSON.parse(localStorage.getItem('violationContact')) || {}
-  } catch (e) {
-    return {}
-  }
-}
-
 const ContentPanel = styled.div`
   background-color: white;
   margin: 30px auto;
@@ -172,63 +174,58 @@ export default (props) => {
   const { unit } = useParams()
 
   const [data, setData] = useState(null)
+  const { executeRecaptcha } = process.env.GOOGLE_RECAPTCHA_KEY
+    ? useGoogleReCaptcha()
+    : { executeRecaptcha: null }
   const savedContact = getSavedContact()
-  const hasSavedContact = !!(
-    savedContact.name &&
-    savedContact.email &&
-    savedContact.phone
+  const [hasSavedContact, setHasSavedContact] = useState(
+    !!(savedContact.name && savedContact.email && savedContact.phone)
   )
   const [videoDescription, setVideoDescription] = useState('')
   const [videoName, setVideoName] = useState(savedContact.name || '')
   const [videoEmail, setVideoEmail] = useState(savedContact.email || '')
   const [videoPhone, setVideoPhone] = useState(savedContact.phone || '')
   const [videoSubmitState, setVideoSubmitState] = useState(null)
-  const videoSubmitting = useRef(false)
-
-  const formatPhone = (phone) =>
-    /^0[1-9][0-9]{8}$/.test(phone)
-      ? phone.replace(/^0(.+)/, '+359$1')
-      : /^0{0,2}359[1-9][0-9]{8}$/.test(phone)
-      ? phone.replace(/^0{0,2}359(.+)/, '+359$1')
-      : phone
+  const [videoSubmitting, setVideoSubmitting] = useState(false)
 
   const videoFormValid =
     videoDescription.length >= 20 &&
     videoName.length > 0 &&
-    videoEmail.length > 0 &&
-    videoPhone.length > 0
+    isValidEmail(videoEmail) &&
+    videoPhone.length > 0 &&
+    isValidPhone(videoPhone)
 
   const submitVideoSignal = async () => {
-    if (videoSubmitting.current || !videoFormValid) return
-    videoSubmitting.current = true
+    if (videoSubmitting || !videoFormValid) return
+    setVideoSubmitting(true)
     setVideoSubmitState(null)
     try {
       const phone = formatPhone(videoPhone)
-      await api.post('violations', {
-        description: videoDescription,
-        section: data.segment,
-        town: parseInt(data.town.id, 10),
-        name: videoName,
-        email: videoEmail,
-        phone,
-        type: 'video',
-      })
-      try {
-        localStorage.setItem(
-          'violationContact',
-          JSON.stringify({
-            name: videoName,
-            email: videoEmail,
-            phone: videoPhone,
-          })
-        )
-      } catch (e) {}
+      await api.post(
+        'violations',
+        {
+          description: videoDescription,
+          section: data.segment,
+          town: parseInt(data.town.id, 10),
+          name: videoName,
+          email: videoEmail,
+          phone,
+          type: 'video',
+        },
+        {
+          headers: executeRecaptcha
+            ? { 'x-recaptcha-token': await executeRecaptcha('sendViolation') }
+            : {},
+        }
+      )
+      saveContact({ name: videoName, email: videoEmail, phone: videoPhone })
+      setHasSavedContact(true)
       setVideoSubmitState('success')
       setVideoDescription('')
     } catch (e) {
       setVideoSubmitState('error')
     }
-    videoSubmitting.current = false
+    setVideoSubmitting(false)
   }
 
   useEffect(() => {
@@ -323,6 +320,7 @@ export default (props) => {
               2
             )}.html#${data.segment}`}
             target="_blank"
+            rel="noopener noreferrer"
           >
             &#9654; Видеоизлъчване от секцията
           </a>
@@ -330,7 +328,10 @@ export default (props) => {
             <textarea
               placeholder="Опишете нарушението от видеонаблюдението..."
               value={videoDescription}
-              onChange={(e) => setVideoDescription(e.target.value)}
+              onChange={(e) => {
+                setVideoDescription(e.target.value)
+                if (videoSubmitState) setVideoSubmitState(null)
+              }}
             />
             {!hasSavedContact && (
               <div className="contact-fields">
@@ -357,7 +358,7 @@ export default (props) => {
             <div className="form-row">
               <Button
                 type="button"
-                disabled={videoSubmitting.current || !videoFormValid}
+                disabled={videoSubmitting || !videoFormValid}
                 onClick={submitVideoSignal}
               >
                 Подай видео сигнал

--- a/src/components/units/Section.js
+++ b/src/components/units/Section.js
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState } from 'react'
+import React, { useContext, useEffect, useState, useRef } from 'react'
 
 import axios from 'axios'
 import Helmet from 'react-helmet'
@@ -18,7 +18,8 @@ import styled from 'styled-components'
 import ViolationFeeds from '../ViolationFeeds'
 import Player from '../embeds/Player'
 import { shouldShowOfficialStreaming } from '../../utils/visibility'
-import { Link as AppLink } from '../components/Link'
+import { Button } from '../components/Button'
+import api from '../../utils/api'
 
 const renderRiskLevelText = (riskLevel) => {
   switch (riskLevel) {
@@ -87,24 +88,67 @@ const VideoPanel = styled.div`
     &:hover {
       opacity: 0.8;
     }
-
-    svg {
-      margin-right: 8px;
-    }
   }
 
-  .signal-link {
-    display: block;
-    margin-top: 12px;
-    font-size: 14px;
-    color: #666;
-    text-decoration: none;
+  .signal-form {
+    margin-top: 16px;
 
-    &:hover {
-      color: #38decb;
+    textarea {
+      width: 100%;
+      padding: 10px;
+      font-size: 16px;
+      border: 1px solid #ccc;
+      border-radius: 6px;
+      resize: vertical;
+      min-height: 60px;
+      box-sizing: border-box;
+      font-family: inherit;
+    }
+
+    .contact-fields {
+      display: flex;
+      gap: 8px;
+      margin-top: 8px;
+
+      input {
+        flex: 1;
+        padding: 8px 10px;
+        font-size: 14px;
+        border: 1px solid #ccc;
+        border-radius: 6px;
+        font-family: inherit;
+      }
+    }
+
+    .form-row {
+      display: flex;
+      gap: 10px;
+      align-items: center;
+      margin-top: 8px;
+    }
+
+    .form-message {
+      margin-top: 8px;
+      font-size: 14px;
+    }
+
+    .success {
+      color: green;
+    }
+
+    .error {
+      color: red;
     }
   }
 `
+
+const getSavedContact = () => {
+  try {
+    return JSON.parse(localStorage.getItem('violationContact')) || {}
+  } catch (e) {
+    return {}
+  }
+}
 
 const ContentPanel = styled.div`
   background-color: white;
@@ -128,6 +172,64 @@ export default (props) => {
   const { unit } = useParams()
 
   const [data, setData] = useState(null)
+  const savedContact = getSavedContact()
+  const hasSavedContact = !!(
+    savedContact.name &&
+    savedContact.email &&
+    savedContact.phone
+  )
+  const [videoDescription, setVideoDescription] = useState('')
+  const [videoName, setVideoName] = useState(savedContact.name || '')
+  const [videoEmail, setVideoEmail] = useState(savedContact.email || '')
+  const [videoPhone, setVideoPhone] = useState(savedContact.phone || '')
+  const [videoSubmitState, setVideoSubmitState] = useState(null)
+  const videoSubmitting = useRef(false)
+
+  const formatPhone = (phone) =>
+    /^0[1-9][0-9]{8}$/.test(phone)
+      ? phone.replace(/^0(.+)/, '+359$1')
+      : /^0{0,2}359[1-9][0-9]{8}$/.test(phone)
+      ? phone.replace(/^0{0,2}359(.+)/, '+359$1')
+      : phone
+
+  const videoFormValid =
+    videoDescription.length >= 20 &&
+    videoName.length > 0 &&
+    videoEmail.length > 0 &&
+    videoPhone.length > 0
+
+  const submitVideoSignal = async () => {
+    if (videoSubmitting.current || !videoFormValid) return
+    videoSubmitting.current = true
+    setVideoSubmitState(null)
+    try {
+      const phone = formatPhone(videoPhone)
+      await api.post('violations', {
+        description: videoDescription,
+        section: data.segment,
+        town: parseInt(data.town.id, 10),
+        name: videoName,
+        email: videoEmail,
+        phone,
+        type: 'video',
+      })
+      try {
+        localStorage.setItem(
+          'violationContact',
+          JSON.stringify({
+            name: videoName,
+            email: videoEmail,
+            phone: videoPhone,
+          })
+        )
+      } catch (e) {}
+      setVideoSubmitState('success')
+      setVideoDescription('')
+    } catch (e) {
+      setVideoSubmitState('error')
+    }
+    videoSubmitting.current = false
+  }
 
   useEffect(() => {
     axios
@@ -222,14 +324,56 @@ export default (props) => {
             )}.html#${data.segment}`}
             target="_blank"
           >
-            &#9654; Видеоизлъчване от СИК
+            &#9654; Видеоизлъчване от секцията
           </a>
-          <AppLink
-            className="signal-link"
-            to={`/violation/new?unit=${data.segment}&type=video`}
-          >
-            Подай видео сигнал &rarr;
-          </AppLink>
+          <div className="signal-form">
+            <textarea
+              placeholder="Опишете нарушението от видеонаблюдението..."
+              value={videoDescription}
+              onChange={(e) => setVideoDescription(e.target.value)}
+            />
+            {!hasSavedContact && (
+              <div className="contact-fields">
+                <input
+                  type="text"
+                  placeholder="Име"
+                  value={videoName}
+                  onChange={(e) => setVideoName(e.target.value)}
+                />
+                <input
+                  type="email"
+                  placeholder="Имейл"
+                  value={videoEmail}
+                  onChange={(e) => setVideoEmail(e.target.value)}
+                />
+                <input
+                  type="tel"
+                  placeholder="Телефон"
+                  value={videoPhone}
+                  onChange={(e) => setVideoPhone(e.target.value)}
+                />
+              </div>
+            )}
+            <div className="form-row">
+              <Button
+                type="button"
+                disabled={videoSubmitting.current || !videoFormValid}
+                onClick={submitVideoSignal}
+              >
+                Подай видео сигнал
+              </Button>
+            </div>
+            {videoSubmitState === 'success' && (
+              <p className="form-message success">
+                Сигналът беше изпратен успешно!
+              </p>
+            )}
+            {videoSubmitState === 'error' && (
+              <p className="form-message error">
+                Грешка при изпращане. Опитайте с подробния формуляр.
+              </p>
+            )}
+          </div>
         </VideoPanel>
       )}
       {/*<Player section={data.segment} />*/}

--- a/src/utils/contact.js
+++ b/src/utils/contact.js
@@ -1,0 +1,33 @@
+const STORAGE_KEY = 'violationContact'
+
+export const getSavedContact = () => {
+  try {
+    return JSON.parse(localStorage.getItem(STORAGE_KEY)) || {}
+  } catch (e) {
+    return {}
+  }
+}
+
+export const saveContact = ({ name, email, phone }) => {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ name, email, phone }))
+  } catch (e) {}
+}
+
+const PHONE_LOCAL_RE = /^0[1-9][0-9]{8}$/
+const PHONE_INTL_RE = /^0{0,2}359[1-9][0-9]{8}$/
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+export const formatPhone = (phone) =>
+  PHONE_LOCAL_RE.test(phone)
+    ? phone.replace(/^0(.+)/, '+359$1')
+    : PHONE_INTL_RE.test(phone)
+    ? phone.replace(/^0{0,2}359(.+)/, '+359$1')
+    : phone
+
+export const isValidPhone = (phone) =>
+  /^\+(?:[0-9] ?){6,14}[0-9]$/.test(phone) ||
+  PHONE_LOCAL_RE.test(phone) ||
+  PHONE_INTL_RE.test(phone)
+
+export const isValidEmail = (email) => EMAIL_RE.test(email)


### PR DESCRIPTION
## Summary
- Embed an inline video signal form directly on the section page (textarea + contact fields + submit button) inside the video panel, so video observers can quickly report violations without navigating away
- Auto-fill and hide contact fields (name, email, phone) when previously saved in localStorage
- Enforce consistent 20-character minimum for violation descriptions across both frontend forms
- Change "Подай сигнал" in violation feeds from a button to a simple link

## Test plan
- [ ] Open a section page when `shouldShowOfficialStreaming` is true — verify inline video signal form appears below the streaming link
- [ ] Submit a video signal with 20+ char description and contact details — verify success message and localStorage persistence
- [ ] Reload the section page — verify contact fields are hidden (pre-filled from localStorage)
- [ ] Try submitting with less than 20 characters — verify button stays disabled
- [ ] Open `/violation/new` — verify description requires 20 chars for both standard and video types
- [ ] Check the violations feed — verify "Подай сигнал" is a simple link, not a button

🤖 Generated with [Claude Code](https://claude.com/claude-code)